### PR TITLE
Manipulate the $_POST array as well.

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -133,6 +133,7 @@
 					continue;
 				}
 
+				self::setArrayValue($_POST['fields'], $field, $value, ($dv['override'] == 'yes'));
 				self::setArrayValue($context['fields'], $field, $value, ($dv['override'] == 'yes'));
 			}
 		}


### PR DESCRIPTION
Allows, for example, a custom field's checkPostFieldData() function to rely on the $_POST array.

Maybe I have overseen implications (so please think about it), but it worked fine for me.

Please note that I send this pull request to integration although your master is ahead of integration (which should be fixed).
