### PR TITLE
Allow for custom values to have keys not starting at 0

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -64,12 +64,8 @@
 			if(is_array($_POST['default_event_values'])) {
 				foreach($_POST['default_event_values'] as $field => $dv) {
 					if($field == 'custom_value') {
-						$max = count($_POST['default_event_values']['custom_value']);
-
-						for($i = 0; $i <= $max; $i++) {
-							if(!isset($_POST['default_event_values']['custom_value'][$i])) continue;
-
-							$default_values .= self::addCustomDefaultValue($_POST['default_event_values']['custom_value'][$i]);
+						foreach($dv as $custom_value) {
+							$default_values .= self::addCustomDefaultValue($custom_value);
 						}
 					}
 					else {


### PR DESCRIPTION
Because of the for loop with $i starting at 0, if custom values were added after non-custom values they would be ignored because their keys did not start at 0.
