### PR TITLE
Fix interface position

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -256,7 +256,7 @@
 			);
 
 			$fieldset->appendChild($div);
-			$form->insertChildAt(2, $fieldset);
+			$form->insertChildAt(3, $fieldset);
 		}
 
 		private function injectDefaultValues(XMLElement &$form, Event $event, Section $section) {
@@ -313,7 +313,7 @@
 			$frame->appendChild($ol);
 			$div->appendChild($frame);
 			$fieldset->appendChild($div);
-			$form->insertChildAt(2, $fieldset);
+			$form->insertChildAt(3, $fieldset);
 		}
 
 	/*-------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the position of the Default Event Values GUI on the event page.

It has been tested with Symphony 2.6.x, but is likely to not work perfectly with older versions — with Symphony 2.5.x I experienced the position [changing with the context (new/edit)](https://github.com/brendo/default_event_values/pull/15#issuecomment-56405244).

I suggest to nevertheless regard issues discussed in #15 as closed when this PR has been pulled. A small glitch in older versions of Symphony is no big deal, IMHO.
